### PR TITLE
chore/npm-scripts: set main entrypoint to dist/server.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "algexplore-backend",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "dist/server.js",
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
     "build": "tsc -p .",


### PR DESCRIPTION
### Contexte
Dans le cadre du ticket ARCH-2, il était nécessaire de fiabiliser le démarrage de l'API
en environnement développement et production.

### Modifications apportées
- Ajout/validation des scripts npm :
  - `npm run dev` : démarre l’API avec ts-node-dev
  - `npm run build` : compile TypeScript vers JavaScript (dossier dist/)
  - `npm start` : exécute le code compilé
- Mise à jour du champ "main" dans package.json -> dist/server.js
- Vérification/validation du fichier tsconfig.json (rootDir=src, outDir=dist, options strictes)

### Tests réalisés
- `npm run dev` : serveur démarre, endpoint `/health` renvoie 200 { "status": "ok" }
- `npm run build && npm start` : serveur démarre depuis dist/, `/health` renvoie 200

### Résultat attendu
Le projet peut être lancé de manière fiable en développement et production.