### PR TITLE
feat/config-service: strict ENV variables validation (Zod) + complete…

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,31 +1,18 @@
-# API
-# Port du backend Express
+# Environnement
+NODE_ENV=development
 PORT=3000
 
-# Origine autorisée (front Angular en dev)
-CORS_ORIGIN=http://localhost:4200
+# CORS (origines autorisées, séparées par des virgules)
+# Exemple: http://localhost:4200,http://localhost:3000
+CORS_ORIGINS=http://localhost:4200
 
-
-# PostgreSQL
-# Identifiants de la base de données
-POSTGRES_USER=your_username
-POSTGRES_PASSWORD=your_password
-POSTGRES_DB=your_database
-POSTGRES_PORT=5432
-
-
-# Connexion Prisma
-# En local (backend lancé depuis ta machine) :
-# DATABASE_URL=postgresql://your_username:your_password@127.0.0.1:5433/your_database?schema=public
-#
-# Dans Docker (backend lancé dans un conteneur) :
-# DATABASE_URL=postgresql://your_username:your_password@db:5432/your_database?schema=public
+# Base de données PostgreSQL (adapter USER, PASSWORD, DBNAME, HOST, PORT)
+# Exemple local : postgresql://USER:PASSWORD@127.0.0.1:5432/DBNAME?schema=public
 DATABASE_URL=
 
-
-# Shadow DB (optionnel, pour Prisma migrate dev)
-# Créez une base "your_database_shadow" et indiquez-la ici
-# Utilisée uniquement en développement pour comparer les migrations
-# Exemple :
-# SHADOW_DATABASE_URL=postgresql://your_username:your_password@127.0.0.1:5433/your_database_shadow?schema=public
+# Shadow DB (optionnel, utilisé par Prisma en dev)
 SHADOW_DATABASE_URL=
+
+# Rate limiting
+RATE_WINDOW_MIN=15
+RATE_MAX_REQ=200

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,11 +1,51 @@
+// import 'dotenv/config';
+
+// export const ENV = {
+//   NODE_ENV: process.env.NODE_ENV ?? 'development',
+//   PORT: Number(process.env.PORT ?? 3000),
+//   CORS_ORIGIN: process.env.CORS_ORIGIN ?? 'http://localhost:4200'
+// };
+
+
+
+
+// src/config/env.ts
 import 'dotenv/config';
+import { z } from 'zod';
+
+const EnvSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  PORT: z.coerce.number().int().positive().default(3000),
+
+  // Base de données
+  DATABASE_URL: z.string().url('DATABASE_URL doit être une URL valide'),
+
+  // Optionnel (Prisma shadow DB)
+  SHADOW_DATABASE_URL: z.string().url().optional(),
+
+  // CORS (liste séparée par des virgules)
+  CORS_ORIGINS: z.string().default('http://localhost:4200'),
+
+  // Rate limit basique (pour futurs tickets Sécurité)
+  RATE_WINDOW_MIN: z.coerce.number().int().positive().default(15),
+  RATE_MAX_REQ: z.coerce.number().int().positive().default(200),
+});
+
+const parsed = EnvSchema.safeParse(process.env);
+
+if (!parsed.success) {
+  const issues = parsed.error.issues
+    .map(i => `- ${i.path.join('.')}: ${i.message}`)
+    .join('\n');
+  // Arrêt propre si config invalide
+  console.error('Configuration ENV invalide :\n' + issues);
+  process.exit(1);
+}
 
 export const ENV = {
-  NODE_ENV: process.env.NODE_ENV ?? 'development',
-  PORT: Number(process.env.PORT ?? 3000),
-  CORS_ORIGIN: process.env.CORS_ORIGIN ?? 'http://localhost:4200'
+  ...parsed.data,
+  // Normalisation pratique : tableau d’origines
+  CORS_ORIGIN_LIST: parsed.data.CORS_ORIGINS.split(',')
+    .map(o => o.trim())
+    .filter(Boolean),
 };
-
-
-
-


### PR DESCRIPTION
### Contexte
Mise en place d’un service de configuration centralisé et validé (ticket ARCH-3).

### Modifications
- Ajout validation stricte avec Zod dans src/config/env.ts
- Complétion du .env.template (NODE_ENV, PORT, CORS_ORIGINS, DATABASE_URL, RATE_*)
- Processus bloqué si configuration invalide

### Tests
- Cas OK : API démarre et /health renvoie 200 avec un .env complet
- Cas KO : API refuse de démarrer si PORT invalide ou DATABASE_URL vide (message clair en console)

### Résultat attendu
Configuration centralisée, validée et documentée.