### PR TITLE
sec/cors-rate-limit : drive CORS and rate limiting via ENV + add JSON 429 response

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -29,13 +29,23 @@ app.use(express.json({ limit: '10kb' })); // Limite la taille des bodies
 app.use(cookieParser()); // Lecture des cookies
 app.use(pinoHttp());
 
-// Rate limiting basique (seront branchés sur ENV dans SEC-2)
+// Rate limiting configuré via ENV
 app.use(
   rateLimit({
-    windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 200,                 // 200 requêtes / 15 min / IP
+    windowMs: ENV.RATE_WINDOW_MIN * 60 * 1000, // Convertit minutes → millisecondes
+    max: ENV.RATE_MAX_REQ,                     // Nombre max de requêtes par IP
     standardHeaders: true,
     legacyHeaders: false,
+    handler: (_req, res) => {
+      res.status(429).json({
+        error: {
+          code: 'TOO_MANY_REQUESTS',
+          message: 'Trop de requêtes. Réessaie dans quelques minutes.',
+          windowMinutes: ENV.RATE_WINDOW_MIN,
+          limit: ENV.RATE_MAX_REQ,
+        },
+      });
+    },
   })
 );
 


### PR DESCRIPTION
### Contexte
Branchement de CORS et du rate-limit sur les variables d’environnement (ticket SEC-2).

### Modifications
- CORS basé sur CORS_ORIGINS (déjà en place)
- Rate-limit basé sur RATE_WINDOW_MIN et RATE_MAX_REQ
- Réponse 429 JSON standardisée

### Tests
- Origine autorisée -> OK ; origine non listée -> bloquée (erreur CORS navigateur)
- Dépassement du quota -> 429, headers RateLimit-* cohérents avec ENV

### Résultat attendu
Paramétrage sécurité ajustable sans changement de code (via .env).
