### PR TITLE
feat/http-errors: add JSON 404 and global error handler

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,8 @@ import rateLimit from 'express-rate-limit'; // Limiter le nombre de requêtes
 import pinoHttp from 'pino-http';
 import cookieParser from 'cookie-parser';
 import { ENV } from './config/env';
+import { AppError } from './errors/AppError'; 
+import { errorHandler } from './middlewares/errorHandler'; 
 
 const app = express();
 
@@ -53,5 +55,24 @@ app.use(
 app.get('/health', (_req, res) => {
   res.status(200).json({ status: 'ok' });
 });
+
+// Route de test d’erreur volontaire
+// Cette route simule une erreur serveur inattendue (500) pour vérifier la gestion des erreurs (errorHandler).
+// fonctionne bien/
+// Quand on appelle /boom -> une erreur est lancée -> interceptée par errorHandler
+app.get('/boom', (_req, _res) => {
+  throw new Error('Boom');
+});
+
+// Middleware 404
+// Doit être le dernier middleware avant errorHandler
+// car il attrape les routes non gérées
+app.use((_req, _res, next) => next(AppError.notFound()));
+
+// Middleware global de gestion des erreurs
+// Il intercepte toutes les erreurs passées à next(err)
+// - Si cest une AppError (ex: NOT_FOUND, BAD_REQUEST), il renvoie le JSON prévu
+// - Sinon, il renvoie une erreur 500 générique pour ne pas exposer les détails internes
+app.use(errorHandler);
 
 export default app;

--- a/src/errors/AppError.ts
+++ b/src/errors/AppError.ts
@@ -1,0 +1,15 @@
+export class AppError extends Error {
+  public status: number;
+  public code: string;
+
+  constructor(status: number, code: string, message?: string) {
+    super(message ?? code);
+    this.status = status;
+    this.code = code;
+    Error.captureStackTrace?.(this, AppError);
+  }
+
+  static notFound(msg = 'Route not found') {
+    return new AppError(404, 'NOT_FOUND', msg);
+  }
+}

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -1,0 +1,26 @@
+import type { Request, Response, NextFunction } from 'express';
+import { AppError } from '../errors/AppError';
+import { ENV } from '../config/env';
+
+export function errorHandler(err: unknown, _req: Request, res: Response, _next: NextFunction) {
+  // Erreurs "connues" de l'app
+  if (err instanceof AppError) {
+    return res.status(err.status).json({
+      error: { code: err.code, message: err.message },
+    });
+  }
+
+  // Erreurs génériques
+  const message = 'Unexpected error';
+  if (ENV.NODE_ENV !== 'production') {
+    // En dev: log détaillé
+    // eslint-disable-next-line no-console
+    console.error('[ERROR]', err);
+  }
+
+  return res.status(500).json({
+    error: { code: 'INTERNAL_SERVER_ERROR', message },
+  });
+}
+// En production, on ne détaille pas l'erreur pour éviter de divulguer des infos sensibles
+// En dev, on loggue l'erreur complète dans la console pour aider au debug


### PR DESCRIPTION
### Contexte
Mise en place d’un système de gestion d’erreurs cohérent et centralisé (ticket ARCH-4).  
Objectif : uniformiser les réponses d’erreurs côté API pour que le front puisse les traiter facilement.

### Modifications
- Création de la classe `AppError` pour standardiser les erreurs applicatives (code + status).
- Ajout du middleware global `errorHandler` :
  - Renvoie un JSON pour toutes les erreurs.
  - Distingue les erreurs applicatives (AppError) et les erreurs internes.
  - Log plus détaillé en environnement de développement.
- Ajout d’un middleware 404 :
  - Retourne `{ "error": { "code": "NOT_FOUND", "message": "Route not found" } }` pour les routes inexistantes.
- Ajout d’une route temporaire `/boom` pour tester les erreurs 500.

### Tests effectués
- `GET /health` → 200 OK  
- `GET /unknown` → 404 JSON `{ error: { code: "NOT_FOUND" } }`  
- `GET /boom` → 500 JSON `{ error: { code: "INTERNAL_SERVER_ERROR" } }` + log en console

### Résultat attendu
- Réponses d’erreurs normalisées et cohérentes sur toute l’API.  
- Comportement fiable pour les erreurs 404 et 500.  
- Préparation du back pour la communication front (Angular).
