### PR TITLE
feat/create-lieu : creation of a place (POST /lieux) with Zod validation and Prisma insertion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express-rate-limit": "^8.1.0",
         "helmet": "^8.1.0",
         "pino-http": "^10.5.0",
-        "zod": "^4.1.11"
+        "zod": "^4.1.12"
       },
       "devDependencies": {
         "@types/cookie-parser": "^1.4.9",
@@ -2372,9 +2372,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
-      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express-rate-limit": "^8.1.0",
     "helmet": "^8.1.0",
     "pino-http": "^10.5.0",
-    "zod": "^4.1.11"
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.9",
@@ -33,6 +33,6 @@
     "typescript": "^5.9.2"
   },
   "prisma": {
-  "seed": "ts-node prisma/seed.ts"
+    "seed": "ts-node prisma/seed.ts"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,8 +7,13 @@ import cookieParser from 'cookie-parser';
 import { ENV } from './config/env';
 import { AppError } from './errors/AppError'; 
 import { errorHandler } from './middlewares/errorHandler'; 
+import lieuxRouter from './routes/lieux.routes';
 
 const app = express();
+
+
+app.use(express.json()); // pour lire le body JSON
+app.use('/lieux', lieuxRouter); 
 
 // Sécurité & middlewares
 app.disable('x-powered-by'); // Cache le fait qu’on utilise Express

--- a/src/middlewares/validate.ts
+++ b/src/middlewares/validate.ts
@@ -1,0 +1,16 @@
+import { ZodObject } from 'zod';
+import { Request, Response, NextFunction } from 'express';
+
+export const validate =
+  (schema: ZodObject) =>
+  (req: Request, res: Response, next: NextFunction) => {
+    const parsed = schema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Validation failed',
+        issues: parsed.error.issues.map(i => ({ path: i.path, message: i.message })),
+      });
+    }
+    req.body = parsed.data; // body nettoyé/typé
+    next();
+  };

--- a/src/routes/lieux.routes.ts
+++ b/src/routes/lieux.routes.ts
@@ -1,0 +1,77 @@
+import { Router, Request, Response } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { validate } from '../middlewares/validate';
+import { LieuCreateSchema } from '../validation/lieu.schema';
+
+const prisma = new PrismaClient();
+const router = Router();
+
+router.post('/', validate(LieuCreateSchema), async (req: Request, res: Response) => {
+  try {
+    const {
+      nom, description, adresse, dateCreation, dateDebut, dateFin,
+      prixAdulte, prixEnfant, latitude, longitude, publicCible,
+      urlInfos, infosAcces, quartierNom, categories,
+    } = req.body;
+
+    // 1) Quartier (créé s'il n'existe pas)
+    const quartier = await prisma.quartier.upsert({
+      where: { nom: quartierNom },
+      update: {},
+      create: { nom: quartierNom },
+    });
+
+    // 2) Créer le lieu
+    const lieu = await prisma.lieu.create({
+      data: {
+        nom,
+        description,
+        adresse,
+        dateCreation: new Date(dateCreation),
+        dateDebut: dateDebut ? new Date(dateDebut) : null,
+        dateFin: dateFin ? new Date(dateFin) : null,
+        prixAdulte: prixAdulte ?? null,
+        prixEnfant: prixEnfant ?? null,
+        latitude: latitude ?? null,   // Decimal -> string OK
+        longitude: longitude ?? null, // Decimal -> string OK
+        publicCible: publicCible ?? null,
+        urlInfos: urlInfos ?? null,
+        infosAcces: infosAcces ?? null,
+        quartier: { connect: { id: quartier.id } },
+      },
+    });
+
+    // 3) Rattacher les catégories (créées si absentes)
+    if (Array.isArray(categories) && categories.length) {
+      for (const nomCat of categories) {
+        const cat = await prisma.categorie.upsert({
+          where: { nom: nomCat },
+          update: {},
+          create: { nom: nomCat },
+        });
+        await prisma.lieuCategorie.upsert({
+          where: { lieuId_categorieId: { lieuId: lieu.id, categorieId: cat.id } },
+          update: {},
+          create: { lieuId: lieu.id, categorieId: cat.id },
+        });
+      }
+    }
+
+    // 4) Retourne le lieu complet (avec relations)
+    const full = await prisma.lieu.findUnique({
+      where: { id: lieu.id },
+      include: {
+        quartier: true,
+        categories: { include: { categorie: true } },
+        photos: true,
+      },
+    });
+
+    res.status(201).json(full);
+  } catch (err) {
+    console.error('POST /lieux error', err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
+export default router;

--- a/src/validation/lieu.schema.ts
+++ b/src/validation/lieu.schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const LieuCreateSchema = z.object({
+  nom: z.string().min(2).max(250),
+  description: z.string().min(5),
+  adresse: z.string().min(2).max(255),
+  dateCreation: z.coerce.date(),           // accepte string/Date -> Date
+  dateDebut: z.coerce.date().nullable().optional(),
+  dateFin: z.coerce.date().nullable().optional(),
+  prixAdulte: z.string().max(50).nullable().optional(),
+  prixEnfant: z.string().max(50).nullable().optional(),
+  latitude: z.string().nullable().optional(),   // on mettra tel quel dans Prisma (Decimal)
+  longitude: z.string().nullable().optional(),
+  publicCible: z.string().max(100).nullable().optional(),
+  urlInfos: z.string().url().max(255).nullable().optional(),
+  infosAcces: z.string().nullable().optional(),
+  quartierNom: z.string().min(1),               // on rattache par nom unique
+  categories: z.array(z.string().min(1)).default([]),
+});


### PR DESCRIPTION
## Contexte

Mise en place de la création d’un lieu (ticket BDD-CRUD-LIEUX1).
Permet à l’administrateur d’ajouter un nouveau lieu dans la base de données via l’API.

## Modifications

- Ajout de la route POST /lieux
- Validation des données avec Zod (LieuCreateSchema)
- Insertion en base via Prisma
- Création automatique du quartier et des catégories si inexistants
- Retour du lieu complet avec ses relations (quartier, categories, photos)

## Tests

Requête POST /lieux via Postman

Body JSON :

{
  "nom": "Palais des Raïs (Bastion 23)",
  "description": "Complexe historique ottoman au front de mer.",
  "adresse": "Casbah, Alger",
  "dateCreation": "2015-01-01",
  "quartierNom": "Casbah",
  "categories": ["histoire", "architecture"]
}


Statut 201 Created ✅ 
Données visibles dans DBeaver ✅

## Résultat attendu

Le lieu est correctement inséré dans la base (lieu, quartier, categorie, lieu_categorie)
et prêt à être exploité par le front (lecture, filtres, détails).