### PR TITLE
feat/update-lieu: add PUT /lieux/:id for partial update with validation and relation sync

### DIFF
--- a/src/routes/lieux.routes.ts
+++ b/src/routes/lieux.routes.ts
@@ -2,11 +2,138 @@ import { Router, Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { validate } from '../middlewares/validate';
 import { LieuCreateSchema } from '../validation/lieu.schema';
+import { LieuUpdateSchema } from '../validation/lieuUpdate.schema';
 
 const prisma = new PrismaClient();
 const router = Router();
 
-// GET /lieux
+/**
+ * PUT /lieux/:id
+ * Objectif : modifier un lieu existant
+ * Règles :
+ *   - si le lieu n'existe pas -> 404
+ *   - si quartierNom est fourni -> on l'upsert et on relie le lieu
+ *   - si categories est fourni -> on remplace toutes les catégories du lieu
+ */
+router.put('/:id', validate(LieuUpdateSchema), async (req: Request, res: Response) => {
+  try {
+    // 1. Récupérer / valider l'id du lieu
+    const id = Number(req.params.id);
+    if (!Number.isFinite(id)) {
+      return res.status(400).json({ error: 'id invalide' });
+    }
+
+    // 2. Vérifier que le lieu existe
+    const existing = await prisma.lieu.findUnique({ where: { id } });
+    if (!existing) {
+      return res.status(404).json({ error: 'Lieu introuvable' });
+    }
+
+    // 3. Extraire les champs envoyés par le client
+    const {
+      quartierNom,
+      categories,
+      dateCreation,
+      dateDebut,
+      dateFin,
+      latitude,
+      longitude,
+      ...rest // le reste : nom, description, adresse, etc.
+    } = req.body;
+
+    // 4. Préparer les données de mise à jour
+    //    On ne veut pas écraser avec undefined,
+    //    donc on ne met que ce qui est fourni.
+    const dataToUpdate: any = {
+      ...rest,
+    };
+
+    // Dates
+    if (dateCreation !== undefined) {
+      dataToUpdate.dateCreation = dateCreation ? new Date(dateCreation) : null;
+    }
+    if (dateDebut !== undefined) {
+      dataToUpdate.dateDebut = dateDebut ? new Date(dateDebut) : null;
+    }
+    if (dateFin !== undefined) {
+      dataToUpdate.dateFin = dateFin ? new Date(dateFin) : null;
+    }
+
+    // Coordonnées
+    if (latitude !== undefined) {
+      dataToUpdate.latitude = latitude ?? null;
+    }
+    if (longitude !== undefined) {
+      dataToUpdate.longitude = longitude ?? null;
+    }
+
+    // Quartier
+    if (quartierNom !== undefined) {
+      const quartier = await prisma.quartier.upsert({
+        where: { nom: quartierNom },
+        update: {},
+        create: { nom: quartierNom },
+      });
+      dataToUpdate.quartier = { connect: { id: quartier.id } };
+    }
+
+    // 5. Mettre à jour le lieu lui-même
+    await prisma.lieu.update({
+      where: { id },
+      data: dataToUpdate,
+    });
+
+    // 6. Mettre à jour les catégories si on en a reçu
+    if (categories !== undefined) {
+      // On supprime d'abord toutes les associations existantes
+      await prisma.lieuCategorie.deleteMany({
+        where: { lieuId: id },
+      });
+
+      // Puis on recrée à partir du nouveau tableau
+      for (const nomCat of categories) {
+        const cat = await prisma.categorie.upsert({
+          where: { nom: nomCat },
+          update: {},
+          create: { nom: nomCat },
+        });
+
+        await prisma.lieuCategorie.create({
+          data: {
+            lieuId: id,
+            categorieId: cat.id,
+          },
+        });
+      }
+    }
+
+    // 7. Renvoyer le lieu mis à jour, version complète
+    const full = await prisma.lieu.findUnique({
+      where: { id },
+      include: {
+        quartier: true,
+        categories: { include: { categorie: true } },
+        photos: true,
+      },
+    });
+
+    res.json(full);
+  } catch (err) {
+    console.error('PUT /lieux/:id error', err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
+
+/**
+ * GET /lieux
+ * Query params possibles :
+ *   - page (par défaut 1)
+ *   - pageSize (par défaut 10, max 50)
+ *   - q (recherche texte dans nom / description / adresse)
+ *   - quartier (nom du quartier exact)
+ *   - categorie (nom de catégorie exact)
+ */
 router.get('/', async (req: Request, res: Response) => {
   try {
     // 1. Récupérer / normaliser les paramètres de requête

--- a/src/validation/lieuUpdate.schema.ts
+++ b/src/validation/lieuUpdate.schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+// Tous les champs sont optionnels => l'admin peut modifier partiellement
+export const LieuUpdateSchema = z.object({
+  nom: z.string().min(2, 'Le nom est trop court').max(250).optional(),
+  description: z.string().optional(),
+  adresse: z.string().max(255).optional(),
+  dateCreation: z.coerce.date().optional(),
+  dateDebut: z.coerce.date().nullable().optional(),
+  dateFin: z.coerce.date().nullable().optional(),
+  prixAdulte: z.string().max(50).nullable().optional(),
+  prixEnfant: z.string().max(50).nullable().optional(),
+  latitude: z.union([z.string(), z.number()]).nullable().optional(),
+  longitude: z.union([z.string(), z.number()]).nullable().optional(),
+  publicCible: z.string().max(100).nullable().optional(),
+  urlInfos: z.string().url().max(255).nullable().optional(),
+  infosAcces: z.string().nullable().optional(),
+
+  // Spécifique aux relations
+  quartierNom: z.string().optional(),
+  categories: z.array(z.string().min(1)).optional(), // si présent -> on remplace les catégories
+});


### PR DESCRIPTION
## Contexte
Ajout de la fonctionnalité de mise à jour des lieux (ticket BDD-CRUD-UPDATE-LIEUX3).
Permet à l’administrateur de modifier les informations d’un lieu existant.

## Modifications
- Ajout de la route PUT /lieux/:id
- Création du schéma LieuUpdateSchema pour la validation des données partielles
- Gestion complète de la mise à jour :
modification des champs simples (texte, dates, coordonnées, etc.)
changement de quartier (création auto si inexistant)
remplacement des catégories associées (relation N-N lieu_categorie)
- Vérification de l’existence du lieu avant mise à jour
- Retour du lieu complet mis à jour avec relations (quartier, categories, photos)

## Tests
- Requête PUT /lieux/:id via Postman
{
    "prixAdulte": "500 DA",
    "publicCible": "Familles",
    "categories": ["culture", "patrimoine"]
}
- Statut 200 OK ✅
- Lieu mis à jour en base et visible dans DBeaver ✅
- Quartier et catégories synchronisés correctement ✅

## Résultat attendu
L'admin peut modifier tout ou partie des informations d'un lieu existant avec une mise à jour cohérente des relations côté back.